### PR TITLE
Fixed outside click on iOS 10 + FastClick

### DIFF
--- a/src/ContextMenu.js
+++ b/src/ContextMenu.js
@@ -84,7 +84,7 @@ export default class ContextMenu extends AbstractMenu {
 
     registerHandlers = () => {
         document.addEventListener('mousedown', this.handleOutsideClick);
-        document.addEventListener('ontouchstart', this.handleOutsideClick);
+        document.addEventListener('touchstart', this.handleOutsideClick);
         document.addEventListener('scroll', this.handleHide);
         document.addEventListener('contextmenu', this.handleHide);
         document.addEventListener('keydown', this.handleKeyNavigation);
@@ -93,7 +93,7 @@ export default class ContextMenu extends AbstractMenu {
 
     unregisterHandlers = () => {
         document.removeEventListener('mousedown', this.handleOutsideClick);
-        document.removeEventListener('ontouchstart', this.handleOutsideClick);
+        document.removeEventListener('touchstart', this.handleOutsideClick);
         document.removeEventListener('scroll', this.handleHide);
         document.removeEventListener('contextmenu', this.handleHide);
         document.removeEventListener('keydown', this.handleKeyNavigation);


### PR DESCRIPTION
ContextMenu mistakenly binds to `ontouchstart` event to handle outside clicks, but it should be called `touchstart`, not `ontouchstart`. This breaks outside click handling on iOS 10 with [FastClick](https://github.com/ftlabs/fastclick) installed.